### PR TITLE
revert: support for files without extension on thumbor requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ demo-ui-config.js
 # System Files
 **/.DS_Store
 **/.vscode
+**/.idea

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -278,7 +278,7 @@ class ImageRequest {
     parseRequestType(event) {
         const path = event["path"];
         const matchDefault = new RegExp(/^(\/?)([0-9a-zA-Z+\/]{4})*(([0-9a-zA-Z+\/]{2}==)|([0-9a-zA-Z+\/]{3}=))?$/);
-        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?)(((.(?!(\.[^.\\\/]+$)))*$)|.*(\.jpg$|.\.png$|\.webp$|\.tiff$|\.jpeg$|\.svg$))/i);
+        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?).*(.+jpg|.+png|.+webp|.+tiff|.+jpeg|.+svg)$/i);
         const matchCustom = new RegExp(/(\/?)(.*)(jpg|png|webp|tiff|jpeg|svg)/i);
         const definedEnvironmentVariables = (
             (process.env.REWRITE_MATCH_PATTERN !== "") &&


### PR DESCRIPTION
**Description of changes:**
revert: support for files without extension on thumbor requests
On version 5.2.0 the RegExp to match Thumbor request type was updated to
allow files without extension.

This change results in an unexpected behavior when invalid base64
(truncated) request are made because it returns Thumbor instead of
throwing a RequestTypeError.


**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [X] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
