### PR TITLE
revert: support for files without extension on thumbor requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ demo-ui-config.js
 # System Files
 **/.DS_Store
 **/.vscode
+**/.idea

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -127,7 +127,7 @@ class ImageRequest {
 
             if (originalImage.ContentType) {
                 //If using default s3 ContentType infer from hex headers
-                if(originalImage.ContentType === 'binary/octet-stream') {
+                if(originalImage.ContentType === 'binary/octet-stream' || originalImage.ContentType === 'application/octet-stream') {
                     const imageBuffer = Buffer.from(originalImage.Body);
                     this.ContentType = this.inferImageType(imageBuffer);
                 } else {
@@ -398,7 +398,7 @@ class ImageRequest {
     * @param {Buffer} imageBuffer - Image buffer.
     */
    inferImageType(imageBuffer) {
-    switch(imageBuffer.toString('hex').substring(0,8).toUpperCase()) {
+    switch(imageBuffer.slice(0, 4).toString('hex').toUpperCase()) {
         case '89504E47': return 'image/png';
         case 'FFD8FFDB': return 'image/jpeg';
         case 'FFD8FFE0': return 'image/jpeg';

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -278,7 +278,7 @@ class ImageRequest {
     parseRequestType(event) {
         const path = event["path"];
         const matchDefault = new RegExp(/^(\/?)([0-9a-zA-Z+\/]{4})*(([0-9a-zA-Z+\/]{2}==)|([0-9a-zA-Z+\/]{3}=))?$/);
-        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?)(((.(?!(\.[^.\\\/]+$)))*$)|.*(\.jpg$|.\.png$|\.webp$|\.tiff$|\.jpeg$|\.svg$))/i);
+        const matchThumbor = new RegExp(/^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?).*(.+jpg|.+png|.+webp|.+tiff|.+jpeg|.+svg)$/i);
         const matchCustom = new RegExp(/(\/?)(.*)(jpg|png|webp|tiff|jpeg|svg)/i);
         const definedEnvironmentVariables = (
             (process.env.REWRITE_MATCH_PATTERN !== "") &&

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -698,6 +698,54 @@ describe('getOriginalImage()', function() {
             }
         });
     });
+    describe('005/noExtension', function() {
+        const testFiles = [[0x89,0x50,0x4E,0x47],[0xFF,0xD8,0xFF,0xDB],[0xFF,0xD8,0xFF,0xE0],[0xFF,0xD8,0xFF,0xEE],[0xFF,0xD8,0xFF,0xE1],[0x52,0x49,0x46,0x46],[0x49,0x49,0x2A,0x00],[0x4D,0x4D,0x00,0x2A]];
+        const expectFileType = ["image/png", "image/jpeg", "image/jpeg", "image/jpeg", "image/jpeg", "image/webp", "image/tiff", "image/tiff"];
+        testFiles.forEach(function (test, index) {it('Should pass and infer content type if there is no extension, had default s3 content type and it has a vlid key and a valid bucket', async function() {
+            //Mock
+            mockAws.getObject.mockImplementationOnce(() => {
+                return {
+                    promise() {
+                        return Promise.resolve({
+                            ContentType: 'application/octet-stream',
+                            Body: Buffer.from(new Uint8Array(test))
+                        });
+                    }
+                };
+            })
+
+            // Act
+            const imageRequest = new ImageRequest(s3, secretsManager);
+            const result = await imageRequest.getOriginalImage('validBucket', 'validKey');
+            // Assert
+            expect(mockAws.getObject).toHaveBeenCalledWith({ Bucket: 'validBucket', Key: 'validKey' });
+            expect(result).toEqual(Buffer.from(new Uint8Array(test)));
+            expect(imageRequest.ContentType).toEqual(expectFileType[index]);
+        });})
+        it('Should fail to infer content type if there is no extension and file header is not recognized', async function() {
+            //Mock
+            mockAws.getObject.mockImplementationOnce(() => {
+                return {
+                    promise() {
+                        return Promise.resolve({
+                            ContentType: 'application/octet-stream',
+                            Body: Buffer.from(new Uint8Array(test))
+                        });
+                    }
+                };
+            })
+
+            //Act
+            const imageRequest = new ImageRequest(s3, secretsManager);
+            try {
+                const result = await imageRequest.getOriginalImage('validBucket', 'validKey');
+            } catch(error){
+                //Assert
+                expect(mockAws.getObject).toHaveBeenCalledWith({ Bucket: 'validBucket', Key: 'validKey' });
+                expect(error.status).toEqual(500);
+            }
+        });
+    });
 });
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
DO NOT MERGE! 

**Description of changes:**
revert: support for files without extension on thumbor requests
On version 5.2.0 the RegExp to match Thumbor request type was updated to
allow files without extension.

This change results in an unexpected behavior when invalid base64
(truncated) request are made because it returns Thumbor instead of
throwing a RequestTypeError.


**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [X] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
