### PR TITLE
fix: return image if content-type cannot be infer

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -407,11 +407,10 @@ class ImageRequest {
         case '52494646': return 'image/webp';
         case '49492A00': return 'image/tiff';
         case '4D4D002A': return 'image/tiff';
-        default: throw {
-            status: 500,
-            code: 'RequestTypeError',
-            message: 'The file does not have an extension and the file type could not be inferred. Please ensure that your original image is of a supported file type (jpg, png, tiff, webp, svg). Refer to the documentation for additional guidance on forming image requests.'
-        };   
+        // We have been uploading files for years setting up the content-type as application/octet-stream
+        // until we fix them, let's return a generic `image` instead of throwing an exception because some of the
+        // files doesn't match the validation implemented in this method.
+        default: return 'image';
     }
 }
 }

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -653,7 +653,7 @@ describe('getOriginalImage()', function() {
     describe('004/noExtension', function() {
         const testFiles = [[0x89,0x50,0x4E,0x47],[0xFF,0xD8,0xFF,0xDB],[0xFF,0xD8,0xFF,0xE0],[0xFF,0xD8,0xFF,0xEE],[0xFF,0xD8,0xFF,0xE1],[0x52,0x49,0x46,0x46],[0x49,0x49,0x2A,0x00],[0x4D,0x4D,0x00,0x2A]];
         const expectFileType = ["image/png", "image/jpeg", "image/jpeg", "image/jpeg", "image/jpeg", "image/webp", "image/tiff", "image/tiff"];
-        testFiles.forEach(function (test, index) {it('Should pass and infer content type if there is no extension, had default s3 content type and it has a vlid key and a valid bucket', async function() {
+        testFiles.forEach(function (test, index) {it('Should pass and infer content type if there is no extension, had default s3 content type and it has a valid key and a valid bucket', async function() {
             //Mock
             mockAws.getObject.mockImplementationOnce(() => {
                 return {
@@ -674,7 +674,7 @@ describe('getOriginalImage()', function() {
             expect(result).toEqual(Buffer.from(new Uint8Array(test)));
             expect(imageRequest.ContentType).toEqual(expectFileType[index]);
         });})
-        it('Should fail to infer content type if there is no extension and file header is not recognized', async function() {
+        it('Should infer content "image" type if there is no extension and file header is not recognized', async function() {
             //Mock
             mockAws.getObject.mockImplementationOnce(() => {
                 return {
@@ -689,13 +689,8 @@ describe('getOriginalImage()', function() {
 
             //Act
             const imageRequest = new ImageRequest(s3, secretsManager);
-            try {
-                const result = await imageRequest.getOriginalImage('validBucket', 'validKey');
-            } catch(error){
-                //Assert
-                expect(mockAws.getObject).toHaveBeenCalledWith({ Bucket: 'validBucket', Key: 'validKey' });
-                expect(error.status).toEqual(500);
-            }
+            await imageRequest.getOriginalImage('validBucket', 'validKey');
+            expect(imageRequest.ContentType).toEqual('image');
         });
     });
     describe('005/noExtension', function() {
@@ -722,7 +717,7 @@ describe('getOriginalImage()', function() {
             expect(result).toEqual(Buffer.from(new Uint8Array(test)));
             expect(imageRequest.ContentType).toEqual(expectFileType[index]);
         });})
-        it('Should fail to infer content type if there is no extension and file header is not recognized', async function() {
+        it('Should infer content "image" type if there is no extension and file header is not recognized', async function() {
             //Mock
             mockAws.getObject.mockImplementationOnce(() => {
                 return {
@@ -737,13 +732,8 @@ describe('getOriginalImage()', function() {
 
             //Act
             const imageRequest = new ImageRequest(s3, secretsManager);
-            try {
-                const result = await imageRequest.getOriginalImage('validBucket', 'validKey');
-            } catch(error){
-                //Assert
-                expect(mockAws.getObject).toHaveBeenCalledWith({ Bucket: 'validBucket', Key: 'validKey' });
-                expect(error.status).toEqual(500);
-            }
+            await imageRequest.getOriginalImage('validBucket', 'validKey');
+            expect(imageRequest.ContentType).toEqual('image');
         });
     });
 });


### PR DESCRIPTION
**Description of changes:**
This is very particular to TracktikCloud S3 buckets objects. We have
uploaded a bunch of them with a generic content type
application/octet-stream and some valid images don't pass the validation
to infer the content type using the file header. Let's return by default
image as the content type instead of returning a 500 error until we
apply the fix to our objects.

**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [X] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
