### PR TITLE
feat(TTCLOUD-4868): return 400 if key not present in request and 477 …

### DIFF
--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -237,6 +237,13 @@ class ImageRequest {
         if (requestType === "Default") {
             // Decode the image request and return the image key
             const decoded = this.decodeRequest(event);
+            if (decoded.key === undefined) {
+                throw ({
+                    status: 400,
+                    code: 'ImageEdits::CannotFindImage',
+                    message: 'The image you specified could not be found. Please check your request syntax as well as the bucket you specified to ensure it exists.'
+                });
+            }
             return decoded.key;
         }
 
@@ -343,7 +350,7 @@ class ImageRequest {
                 return JSON.parse(toBuffer.toString());
             } catch (e) {
                 throw ({
-                    status: 400,
+                    status: 477, // 99% of the time is because of a truncated base64 encoded string by Outlook!
                     code: 'DecodeRequest::CannotDecodeRequest',
                     message: 'The image request you provided could not be decoded. Please check that your request is base64 encoded properly and refer to the documentation for additional guidance.'
                 });

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -1036,6 +1036,26 @@ describe('parseImageKey()', function() {
             }
         });
     });
+    describe('007/defaultRequestType/keyNotSpecifiedInRequest', function() {
+        it('Should return 400 if the key is not specified in the request', function() {
+            // Arrange
+            const event = {
+                path : '/eyJidWNrZXQiOiJhbGxvd2VkQnVja2V0MDAxIiwiZWRpdHMiOnsiZ3JheXNjYWxlIjoidHJ1ZSJ9fQ=='
+            }
+            // Act
+            const imageRequest = new ImageRequest(s3, secretsManager);
+            // Assert
+            try {
+                imageRequest.parseImageKey(event, 'Default');
+            } catch (error) {
+                expect(error).toEqual({
+                    status: 400,
+                    code: 'ImageEdits::CannotFindImage',
+                    message: 'The image you specified could not be found. Please check your request syntax as well as the bucket you specified to ensure it exists.'
+                });
+            }
+        });
+    });
 });
 
 // ----------------------------------------------------------------------------
@@ -1213,7 +1233,7 @@ describe('decodeRequest()', function() {
                 imageRequest.decodeRequest(event);
             } catch (error) {
                 expect(error).toEqual({
-                    status: 400,
+                    status: 477,
                     code: 'DecodeRequest::CannotDecodeRequest',
                     message: 'The image request you provided could not be decoded. Please check that your request is base64 encoded properly and refer to the documentation for additional guidance.'
                 });


### PR DESCRIPTION
**Description of changes:**

Return 400 if key not present in request and 477 when request can be decoded

This is a customization in our case to have different alarms sensitivity
for 477 errors because we know they are produced by Outlook truncating
the URL of the images when forwarding the emails.


**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.
