### PR TITLE
S3 timeout retry

### DIFF
--- a/source/image-handler/index.js
+++ b/source/image-handler/index.js
@@ -2,7 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const AWS = require('aws-sdk');
-const s3 = new AWS.S3();
+const s3 = new AWS.S3({
+    maxRetries: 2,
+    retryDelayOptions: {
+        customBackoff: retryCount => {
+            console.log(`retry count: ${retryCount}, waiting: 100ms`)
+            return 100 // in milliseconds
+        }
+    },
+    httpOptions: {
+        connectTimeout: 2000, // in milliseconds
+        timeout: 5000, // in milliseconds
+    },
+});
 const rekognition = new AWS.Rekognition();
 const secretsManager = new AWS.SecretsManager();
 

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -13,7 +13,7 @@
     "sharp": "^0.27.0"
   },
   "devDependencies": {
-    "aws-sdk": "2.771.0",
+    "aws-sdk": "^2.1043.0",
     "jest": "^26.4.2"
   },
   "scripts": {

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -568,9 +568,9 @@ describe('setup()', function() {
                 expect(imageRequest).toEqual(expectedResult);
             } catch (error) {
                 expect(error).toEqual({
-                    status: 400,
-                    code: 'RequestTypeError',
-                    message: 'The type of request you are making could not be processed. Please ensure that your original image is of a supported file type (jpg, png, tiff, webp, svg) and that your image request is provided in the correct syntax. Refer to the documentation for additional guidance on forming image requests.'
+                    status: 477,
+                    code: 'DecodeRequest::CannotDecodeRequest',
+                    message: 'The image request you provided could not be decoded. Please check that your request is base64 encoded properly and refer to the documentation for additional guidance.'
                 });
             }
         });
@@ -1124,9 +1124,9 @@ describe('parseRequestType()', function() {
                 imageRequest.parseRequestType(event);
             } catch (error) {
                 expect(error).toEqual({
-                    status: 400,
-                    code: 'RequestTypeError',
-                    message: 'The type of request you are making could not be processed. Please ensure that your original image is of a supported file type (jpg, png, tiff, webp, svg) and that your image request is provided in the correct syntax. Refer to the documentation for additional guidance on forming image requests.'
+                    status: 477,
+                    code: 'DecodeRequest::CannotDecodeRequest',
+                    message: 'The image request you provided could not be decoded. Please check that your request is base64 encoded properly and refer to the documentation for additional guidance.'
                 });
             }
         });


### PR DESCRIPTION
**Issue #, if available:**
https://tracktik.atlassian.net/browse/TTCLOUD-4903

Add timeout and retry option to S3 client.
Bump aws-sdk dependency to fix 1 vulnerability
Fix tests

**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
