### PR TITLE
chore(deps): bump sharp from 0.27 to 0.30.6

### DIFF
--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "color": "3.1.3",
     "color-name": "1.1.4",
-    "sharp": "^0.27.0"
+    "sharp": "^0.30.6"
   },
   "devDependencies": {
     "@types/color": "^3.0.2",


### PR DESCRIPTION
**Description of changes:**

chore(deps): bump sharp from 0.27 to 0.30.6

This will fix 2 vulnerabilities identified: 
- Regular Expression Denial of Service (ReDoS)  Vulnerability in ansi-regex 2.1.1.  
- Remote Code Execution (RCE) Vulnerability in sharp 0.27.2.

**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [X] :warning: This pull request might incur a breaking change. (Note: I have reviewed the change log of sharp and the only deprecation that I found was that nodejs 10 support was dropped, because we are using nodejs 14 this shouldn't affect us) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
