### PR TITLE
fix: return 400 if key not present in request and 477 when request cannot be decoded

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -325,7 +325,7 @@ export class ImageRequest {
     const { path } = event;
     const matchDefault = /^(\/?)([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
     const matchThumbor =
-      /^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?)(((.(?!(\.[^.\\/]+$)))*$)|.*(\.jpg$|\.jpeg$|.\.png$|\.webp$|\.tiff$|\.tif$|\.svg$|\.gif$))/i;
+      /^(\/?)((fit-in)?|(filters:.+\(.?\))?|(unsafe)?).*(\.jpg$|\.jpeg$|.\.png$|\.webp$|\.tiff$|\.tif$|\.svg$|\.gif$)/i;
     const { REWRITE_MATCH_PATTERN, REWRITE_SUBSTITUTION } = process.env;
     const definedEnvironmentVariables =
       REWRITE_MATCH_PATTERN !== "" &&

--- a/source/image-handler/test/image-request/parse-request-type.spec.ts
+++ b/source/image-handler/test/image-request/parse-request-type.spec.ts
@@ -109,4 +109,27 @@ describe("parseRequestType", () => {
       });
     }
   });
+
+  it("Should throw an error if the request is a truncated base64", () => {
+    // Arrange
+    const event = { path: "ewogICJidWNrZXQiOiAidHQtb3JpZ2luYWwtaW1hZ2UtYnVja2V0IiwKICAia2V5" };
+
+    process.env = {};
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+
+    // Assert
+    try {
+      imageRequest.parseRequestType(event);
+    } catch (error) {
+      expect(consoleInfoSpy).toHaveBeenCalledWith("Path is not base64 encoded.");
+      expect(error).toMatchObject({
+        status: StatusCodes.TRUNCATED_REQUEST,
+        code: "DecodeRequest::CannotDecodeRequest",
+        message:
+          "The image request you provided could not be decoded. Please check that your request is base64 encoded properly and refer to the documentation for additional guidance.",
+      });
+    }
+  });
 });


### PR DESCRIPTION
**Issue :**
fix: return 400 if key not present in request and 477 when request cannot be decoded)


**Description of changes:**
We added the special 477 error code 


**Checklist**
- [X] :wave: I have added unit tests for all code changes.
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
